### PR TITLE
Update jsshaper to work with latest version of Node

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -1,6 +1,6 @@
 "use strict"; "use restrict";
 
-var Fmt = Fmt || require("fmt.js") || Fmt;
+var Fmt = Fmt || require("./fmt.js") || Fmt;
 
 var Log = (function() {
     var _console = (typeof console !== "undefined") && console || {log: print};

--- a/src/narcissus.js
+++ b/src/narcissus.js
@@ -1,10 +1,10 @@
 "empty";
 
 if (typeof Narcissus === "undefined") {
-    require("jsecma5.js");
+    require("./jsecma5.js");
     /* global Narcissus */
-    require("narcissus/lib/jsdefs.js");
-    require("jsmods.js");
-    require("narcissus/lib/jslex.js");
-    require("narcissus/lib/jsparse.js");
+    require("./narcissus/lib/jsdefs.js");
+    require("./jsmods.js");
+    require("./narcissus/lib/jslex.js");
+    require("./narcissus/lib/jsparse.js");
 }

--- a/src/plugins/annotater.js
+++ b/src/plugins/annotater.js
@@ -1,7 +1,7 @@
 "use strict"; "use restrict";
 
-var Shaper = Shaper || require("shaper.js") || Shaper;
-var Comments = Comments || require("comments.js") || Comments;
+var Shaper = Shaper || require("../shaper.js") || Shaper;
+var Comments = Comments || require("../comments.js") || Comments;
 
 Shaper("annotater", function(root) {
     Shaper.traverse(root, {pre: function(node, ref) {

--- a/src/plugins/annotation-printer.js
+++ b/src/plugins/annotation-printer.js
@@ -1,8 +1,8 @@
 "use strict"; "use restrict";
 
-var Shaper = Shaper || require("shaper.js") || Shaper;
-var Fmt = Fmt || require("fmt.js") || Fmt;
-var Annotater = Annotater || require("plugins/annotater.js") || Annotater;
+var Shaper = Shaper || require("../shaper.js") || Shaper;
+var Fmt = Fmt || require("../fmt.js") || Fmt;
+var Annotater = Annotater || require("./annotater.js") || Annotater;
 var log = (typeof console !== "undefined") && console.log || print;
 
 Annotater(/[\s\*](@[_$a-zA-Z0-9]*)/, function(node, match) {

--- a/src/plugins/asserter.js
+++ b/src/plugins/asserter.js
@@ -1,7 +1,7 @@
 "use strict"; "use restrict";
 
-var Shaper = Shaper || require("shaper.js") || Shaper;
-var Fmt = Fmt || require("fmt.js") || Fmt;
+var Shaper = Shaper || require("../shaper.js") || Shaper;
+var Fmt = Fmt || require("../fmt.js") || Fmt;
 
 Shaper("asserter", function(root) {
     var fns = [];

--- a/src/plugins/bitwiser.js
+++ b/src/plugins/bitwiser.js
@@ -1,7 +1,7 @@
 "use strict"; "use restrict";
 
-var Shaper = Shaper || require("shaper.js") || Shaper;
-var Annotater = Annotater || require("plugins/annotater.js") || Annotater;
+var Shaper = Shaper || require("../shaper.js") || Shaper;
+var Annotater = Annotater || require("./annotater.js") || Annotater;
 
 Shaper("bitwiser", function(root) {
     var bitwise_stack = [];

--- a/src/plugins/logger.js
+++ b/src/plugins/logger.js
@@ -1,7 +1,7 @@
 "use strict"; "use restrict";
 
-var Shaper = Shaper || require("shaper.js") || Shaper;
-var Fmt = Fmt || require("fmt.js") || Fmt;
+var Shaper = Shaper || require("../shaper.js") || Shaper;
+var Fmt = Fmt || require("../fmt.js") || Fmt;
 
 Shaper("logger", function(root) {
     var fns = [];

--- a/src/plugins/restricter.js
+++ b/src/plugins/restricter.js
@@ -1,8 +1,8 @@
 "use strict"; "use restrict";
 
-var Fmt = Fmt || require("fmt.js") || Fmt;
-var Shaper = Shaper || require("shaper.js") || Shaper;
-var Annotater = Annotater || require("plugins/annotater.js") || Annotater;
+var Fmt = Fmt || require("../fmt.js") || Fmt;
+var Shaper = Shaper || require("../shaper.js") || Shaper;
+var Annotater = Annotater || require("./annotater.js") || Annotater;
 
 Shaper("restricter", function(root) {
     var restrictfns = [];

--- a/src/plugins/stringconverter.js
+++ b/src/plugins/stringconverter.js
@@ -1,6 +1,6 @@
 "use strict"; "use restrict";
 
-var Shaper = Shaper || require("shaper.js") || Shaper;
+var Shaper = Shaper || require("../shaper.js") || Shaper;
 
 // converts ""+expr or expr+"" to String(expr)
 Shaper("stringconverter", function(root) {

--- a/src/ref.js
+++ b/src/ref.js
@@ -1,6 +1,6 @@
 "use strict"; "use restrict";
 
-var Fmt = Fmt || require("fmt.js") || Fmt;
+var Fmt = Fmt || require("./fmt.js") || Fmt;
 var Ref = (function() {
     // examples:
     // {base: obj, properties: ["property"]}

--- a/src/run-shaper.js
+++ b/src/run-shaper.js
@@ -1,6 +1,5 @@
 "use strict"; "use restrict";
 var require = require || function(f) { load(f); };
-require.paths && typeof __dirname !== "undefined" && require.paths.unshift(__dirname);
 var args = (typeof process !== "undefined" && process.argv !== undefined) ?
     process.argv.slice(2) : arguments;
 var log = (typeof console !== "undefined") && console.log || print;
@@ -14,7 +13,7 @@ if (args.length <= 0) {
 }
 var filename = args.shift();
 
-var Shaper = Shaper || require("shaper.js") || Shaper;
+var Shaper = Shaper || require("./shaper.js") || Shaper;
 
 var pipeline = [];
 while (args.length > 0) {
@@ -24,7 +23,7 @@ while (args.length > 0) {
         pipeline.push(shapename.slice(2));
     }
     else { // plugin
-        require(shapename);
+        require("./" + shapename);
         var slash = shapename.lastIndexOf("/");
         pipeline.push(shapename.slice(slash !== -1 ? slash + 1 : 0, shapename.length - 3));
     }

--- a/src/shaper.js
+++ b/src/shaper.js
@@ -1,13 +1,12 @@
 "use strict"; "use restrict";
 
 var require = require || function(f) { load(f); };
-require.paths && typeof __dirname !== "undefined" && require.paths.unshift(__dirname);
-/* global Narcissus, tkn */ (typeof Narcissus === "undefined") && require("narcissus.js");
-var Fmt = Fmt || require("fmt.js") || Fmt;
-var Ref = Ref || require("ref.js") || Ref;
-var Log = Log || require("log.js") || Log;
-var Assert = Assert || require("assert.js") || Assert;
-var Comments = Comments || require("comments.js") || Comments;
+/* global Narcissus, tkn */ (typeof Narcissus === "undefined") && require("./narcissus.js");
+var Fmt = Fmt || require("./fmt.js") || Fmt;
+var Ref = Ref || require("./ref.js") || Ref;
+var Log = Log || require("./log.js") || Log;
+var Assert = Assert || require("./assert.js") || Assert;
+var Comments = Comments || require("./comments.js") || Comments;
 var log = (typeof console !== "undefined") && console.log || print;
 
 var Shaper = (function() {

--- a/src/shaper.js
+++ b/src/shaper.js
@@ -162,7 +162,7 @@ var Shaper = (function() {
                 return old;
             }
             else if (!(node instanceof Narcissus.parser.Node)) {
-                throw new Error("traverse: visitfns.post invalid return type");
+                throw new Error("traverse: visitfns.pre invalid return type");
             }
         }
 


### PR DESCRIPTION
Node has removed require_paths in the latest versions, so I've changed require() to use full paths instead. I also fixed a minor typo.
