### PR TITLE
Shaper improvements.

### DIFF
--- a/src/plugins/asserter.js
+++ b/src/plugins/asserter.js
@@ -14,13 +14,13 @@ Shaper("asserter", function(root) {
             }
             if (Shaper.match(callTempl, node) || Shaper.match(dotTempl, node)) {
                 var args = node.children[1];
-                var str = Fmt('"{0}, function {1}, file {2}, line {3}"',
-                              args.children[0].getSrc().replace(/"/g, '\\"'),
+                var str = Fmt('{0}, function {1}, file {2}, line {3}',
+                              args.children[0].getSrc(),
                               fns.length === 0 ? "<script>" :
                               fns[fns.length - 1].name || "<anonymous>",
                               node.tokenizer.filename,
                               node.lineno);
-                Shaper.insertBefore(new Ref(args, "children", args.children.length), Shaper.parse(str));
+                Shaper.insertBefore(new Ref(args, "children", args.children.length), Shaper.parse(JSON.stringify(str)));
             }
         },
         post: function(node, ref) {

--- a/src/shaper.js
+++ b/src/shaper.js
@@ -701,7 +701,11 @@ var Shaper = (function() {
         log(root.toString());
     });
     shaper("source", function(root) {
-        log(root.getSrc());
+        var str = root.getSrc();
+        // log is going to add a trailing newline, so suppress the last one
+        // from str (if that's actually what it ends with)
+        if (str[str.length-1]=='\n') { str = str.substring(0, str.length-1); }
+        log(str);
     });
     shaper("version", function(root) {
         log(Fmt("Shaper for JavaScript version {0}", shaper.version));

--- a/src/shaper.js
+++ b/src/shaper.js
@@ -399,7 +399,7 @@ var Shaper = (function() {
         if (children.length === 0) {
             var parens = srcs.pop();
             var last = parens.length - 1;
-            srcs.push(parens.slice(0, last), parens.slice(last));
+            srcs.push(parens.slice(0, last), (delimiter||'')+parens.slice(last));
             children.push(child);
         }
         // has children already, insert new delimiter in srcs


### PR DESCRIPTION
A few general improvements to the Shaper framework: prevent "newline growth" at end of shaped code, fix missing delimited in Shaper._insert, fix string escaping in the asserter.
